### PR TITLE
Update font env var docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ Here are the variables you can edit:
 | `BLOG_FOOTER_TEXT`| the text in the footer ||
 | `BLOG_THEME` | the theme to pass to Tailwind | default |
 | `BLOG_FONT_HEADINGS` | the font-family for all HTML headings, from `h1` to `h6`| sans-serif (default), serif, monospace|
-| `BLOG_FONT_PARAGRAPHS` | the font-family for all other HTML elements | sans-serif (default), serif, monospace|
+| `BLOG_FONT_BODY` | the font-family for all other HTML elements | sans-serif (default), serif, monospace|
 
 All of the env variables can be configured through the [Wizard](https://nextjs-wizard.netlify.app/) or through setting the project's environment variables. You can do this in your Netlify dashaboard (Site settings/Build & deploy/Environment/Environment variables).
 
@@ -82,7 +82,7 @@ https://user-images.githubusercontent.com/3611928/153997545-6dcdeef0-e570-49e7-9
 
 If setting an environment variable isn't your cup of tea, the defaults can be changed in [`utils/global-data.js`](/utils/global-data.js). You can also remove the variables and hard code blog information where these variables are used in the code base.
 
-- `BLOG_THEME, BLOG_FONT_HEADINGS, & BLOG_FONT_PARAGRAPHS` are used in [`tailwind-preset.js`](tailwind-preset.js)
+- `BLOG_THEME, BLOG_FONT_HEADINGS, & BLOG_FONT_BODY` are used in [`tailwind-preset.js`](tailwind-preset.js)
 - `BLOG_NAME, BLOG_TITLE, BLOG_FOOTER_TEXT` are used in [`pages/index.js`](pages/index.js) & [`pages/posts/[slug].js`](pages/posts/[slug].js) through the `globalData` object.
 
 ## Adding new posts

--- a/utils/theme-utils.js
+++ b/utils/theme-utils.js
@@ -2,6 +2,7 @@ const { COLOR_THEMES, FONT_THEMES } = require('../themes');
 
 const THEME = process.env.BLOG_THEME || 'default';
 const FONT_HEADINGS = process.env.BLOG_FONT_HEADINGS || 'sans-serif';
+// body font family variable
 const FONT_BODY = process.env.BLOG_FONT_BODY || 'sans-serif';
 
 export function generateCssVariables() {


### PR DESCRIPTION
## Summary
- revert to `BLOG_FONT_BODY` env var in theme utils
- update README for new env var name

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_685374933c7c83288341c65e79ad50b9