### PR TITLE
Fix README Next.js wording

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 A customizable blog starter using:
 
-- [Next.js](https://github.com/vercel/next.js) v15 (Pages Router)
+- [Next.js](https://github.com/vercel/next.js) v15 (App Router)
 - [Tailwind](https://tailwindcss.com/) v4.x
 - [Netlify Visual Editor](https://docs.netlify.com/visual-editor/overview/)
 - Built-in [MDX](https://mdxjs.com/) support


### PR DESCRIPTION
## Summary
- clarify README references to Next.js App Router

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6853f2f83400832887f32c6e08a6c100