### PR TITLE
Improve post navigation component

### DIFF
--- a/src/app/posts/[slug]/page.tsx
+++ b/src/app/posts/[slug]/page.tsx
@@ -1,130 +1,122 @@
-import {MDXRemote} from 'next-mdx-remote/rsc';
-import Link from 'next/link';
-import Footer from '@/components/Footer';
-import {GradientBackground} from '@/components/GradientBackground';
+import { MDXRemote } from 'next-mdx-remote/rsc';
+import { GradientBackground } from '@/components/GradientBackground';
 import rehypePrettyCode from 'rehype-pretty-code';
 import rehypeUnwrapImages from 'rehype-unwrap-images';
 import remarkGfm from 'remark-gfm';
-import {getGlobalData} from '@/utils/globalData';
+import { getGlobalData } from '@/utils/globalData';
 import {
-    getPostFilePaths,
-    getPostBySlug,
-    getNextPostBySlug,
-    getPreviousPostBySlug,
+  getPostFilePaths,
+  getPostBySlug,
+  getNextPostBySlug,
+  getPreviousPostBySlug,
 } from '@/utils/mdxUtils';
 import CustomLink from '@/components/CustomLink';
 import CustomImage from '@/components/CustomImage';
-import ArrowIcon from '@/components/ArrowIcon';
-import type {Metadata} from 'next';
-import {JSX} from 'react';
+import PostNavCard from '@/components/PostNavCard';
+import type { Metadata } from 'next';
+import { JSX } from 'react';
 
 type AsyncProps = {
-    params: Promise<{ slug: string }>;
+  params: Promise<{ slug: string }>;
 };
 
-export const generateMetadata = async ({params}: AsyncProps): Promise<Metadata> => {
-    const globalData = getGlobalData();
-    const {slug} = await params;
-    const {data} = await getPostBySlug(slug);
-    return {
-        title: `${data.title} - ${globalData.name}`,
-        description: data.description,
-    };
+export const generateMetadata = async ({
+  params,
+}: AsyncProps): Promise<Metadata> => {
+  const globalData = getGlobalData();
+  const { slug } = await params;
+  const { data } = await getPostBySlug(slug);
+  return {
+    title: `${data.title} - ${globalData.name}`,
+    description: data.description,
+  };
 };
 
 const components = {
-    a: CustomLink,
-    img: CustomImage,
+  a: CustomLink,
+  img: CustomImage,
 };
 
-const PostPage = async ({params}: AsyncProps): Promise<JSX.Element> => {
-    const {slug} = await params;
-    const globalData = getGlobalData();
-    const {content, data} = await getPostBySlug(slug);
-    const prevPost = getPreviousPostBySlug(slug);
-    const nextPost = getNextPostBySlug(slug);
+const PostPage = async ({ params }: AsyncProps): Promise<JSX.Element> => {
+  const { slug } = await params;
+  const globalData = getGlobalData();
+  const { content, data } = await getPostBySlug(slug);
+  const prevPost = getPreviousPostBySlug(slug);
+  const nextPost = getNextPostBySlug(slug);
 
-    return (
-        <div>
-            <article className="px-6 md:px-0" data-sb-object-id={`posts/${slug}.mdx`}>
-                <header>
-                    <h1
-                        className="mb-12 text-3xl text-center md:text-5xl dark:text-white"
-                        data-sb-field-path="title"
-                    >
-                        {data.title}
-                    </h1>
-                    {data.description && (
-                        <p className="mb-4 text-xl" data-sb-field-path="description">
-                            {data.description}
-                        </p>
-                    )}
-                </header>
-                <main>
-                    <article className="prose dark:prose-invert" data-sb-field-path="markdown_content">
-                        <MDXRemote
-                            source={content}
-                            components={components}
-                            options={{
-                                mdxOptions: {
-                                    remarkPlugins: [remarkGfm],
-                                    rehypePlugins: [
-                                        [rehypePrettyCode, {theme: 'github-dark', keepBackground: false}],
-                                        rehypeUnwrapImages,
-                                    ],
-                                },
-                            }}
-                        />
-                    </article>
-                </main>
+  return (
+    <div>
+      <article className="px-6 md:px-0" data-sb-object-id={`posts/${slug}.mdx`}>
+        <header>
+          <h1
+            className="mb-12 text-3xl text-center md:text-5xl dark:text-white"
+            data-sb-field-path="title"
+          >
+            {data.title}
+          </h1>
+          {data.description && (
+            <p className="mb-4 text-xl" data-sb-field-path="description">
+              {data.description}
+            </p>
+          )}
+        </header>
+        <main>
+          <article
+            className="prose dark:prose-invert"
+            data-sb-field-path="markdown_content"
+          >
+            <MDXRemote
+              source={content}
+              components={components}
+              options={{
+                mdxOptions: {
+                  remarkPlugins: [remarkGfm],
+                  rehypePlugins: [
+                    [
+                      rehypePrettyCode,
+                      { theme: 'github-dark', keepBackground: false },
+                    ],
+                    rehypeUnwrapImages,
+                  ],
+                },
+              }}
+            />
+          </article>
+        </main>
 
-                <div className="grid mt-12 md:grid-cols-2 lg:-mx-24">
-                    {prevPost && (
-                        <Link
-                            href={`/posts/${prevPost.slug}`}
-                            className="flex flex-col px-10 py-8 text-center transition border border-gray-800/10 bg-white/10 md:text-right first:rounded-t-lg md:first:rounded-tr-none md:first:rounded-l-lg last:rounded-r-lg last:rounded-b-lg backdrop-blur-lg dark:bg-black/30 hover:bg-white/20 dark:hover:bg-black/50 dark:border-white/10 last:border-t md:border-r-0 md:last:border-r md:last:rounded-r-none"
-                        >
-                            <p className="mb-4 text-gray-500 uppercase dark:text-white dark:opacity-60">
-                                Previous
-                            </p>
-                            <h4 className="mb-6 text-2xl text-gray-700 dark:text-white">
-                                {prevPost.title}
-                            </h4>
-                            <ArrowIcon className="mx-auto mt-auto transform rotate-180 md:mr-0"/>
-                        </Link>
-                    )}
-                    {nextPost && (
-                        <Link
-                            href={`/posts/${nextPost.slug}`}
-                            className="flex flex-col px-10 py-8 text-center transition border border-t-0 border-b-0 border-gray-800/10 bg-white/10 md:text-left md:first:rounded-t-lg last:rounded-b-lg first:rounded-l-lg md:last:rounded-bl-none md:last:rounded-r-lg backdrop-blur-lg dark:bg-black/30 hover:bg-white/20 dark:hover:bg-black/50 dark:border-white/10 first:border-t first:rounded-t-lg md:border-t last:border-b"
-                        >
-                            <p className="mb-4 text-gray-500 uppercase dark:text-white dark:opacity-60">
-                                Next
-                            </p>
-                            <h4 className="mb-6 text-2xl text-gray-700 dark:text-white">
-                                {nextPost.title}
-                            </h4>
-                            <ArrowIcon className="mx-auto mt-auto md:ml-0"/>
-                        </Link>
-                    )}
-                </div>
-            </article>
-            <GradientBackground
-                variant="large"
-                className="absolute -top-32 opacity-30 dark:opacity-50"
+        <div className="grid mt-12 md:grid-cols-2 lg:-mx-24">
+          {prevPost && (
+            <PostNavCard
+              slug={prevPost.slug}
+              title={prevPost.title}
+              direction="previous"
             />
-            <GradientBackground
-                variant="small"
-                className="absolute bottom-0 opacity-20 dark:opacity-10"
+          )}
+          {nextPost && (
+            <PostNavCard
+              slug={nextPost.slug}
+              title={nextPost.title}
+              direction="next"
             />
+          )}
         </div>
-    );
+      </article>
+      <GradientBackground
+        variant="large"
+        className="absolute -top-32 opacity-30 dark:opacity-50"
+      />
+      <GradientBackground
+        variant="small"
+        className="absolute bottom-0 opacity-20 dark:opacity-10"
+      />
+    </div>
+  );
 };
 
 export default PostPage;
 
 export const generateStaticParams = async () => {
-    return getPostFilePaths().map((path) => ({
-        slug: path.replace(/\.mdx?$/, ''),
-    }));
+  return getPostFilePaths().map((path) => ({
+    slug: path.replace(/\.mdx?$/, ''),
+  }));
 };

--- a/src/components/PostNavCard.tsx
+++ b/src/components/PostNavCard.tsx
@@ -14,10 +14,10 @@ const PostNavCard = ({ slug, title, direction }: PostNavCardProps) => {
     'flex flex-col px-10 py-8 text-center transition border border-gray-800/10 bg-white/10 backdrop-blur-lg dark:bg-black/30 hover:bg-white/20 dark:hover:bg-black/50 dark:border-white/10';
 
   const prevClasses =
-    'md:text-right first:rounded-t-lg md:first:rounded-tr-none md:first:rounded-l-lg last:rounded-r-lg last:rounded-b-lg last:border-t md:border-r-0 md:last:border-r md:last:rounded-r-none';
+    'md:col-start-1 md:text-right first:rounded-t-lg md:first:rounded-tr-none md:first:rounded-l-lg last:rounded-r-lg last:rounded-b-lg last:border-t md:border-r-0 md:last:border-r md:last:rounded-r-none';
 
   const nextClasses =
-    'border-t-0 border-b-0 md:text-left md:first:rounded-t-lg last:rounded-b-lg first:rounded-l-lg md:last:rounded-bl-none md:last:rounded-r-lg first:border-t md:border-t last:border-b';
+    'md:col-start-2 border-t-0 border-b-0 md:text-left md:first:rounded-t-lg last:rounded-b-lg first:rounded-l-lg md:last:rounded-bl-none md:last:rounded-r-lg first:border-t md:border-t last:border-b';
 
   return (
     <Link

--- a/src/components/PostNavCard.tsx
+++ b/src/components/PostNavCard.tsx
@@ -1,0 +1,38 @@
+import Link from 'next/link';
+import ArrowIcon from '@/components/ArrowIcon';
+
+interface PostNavCardProps {
+  slug: string;
+  title: string;
+  direction: 'next' | 'previous';
+}
+
+const PostNavCard = ({ slug, title, direction }: PostNavCardProps) => {
+  const label = direction === 'next' ? 'Next' : 'Previous';
+  const href = `/posts/${slug}`;
+  const baseClasses =
+    'flex flex-col px-10 py-8 text-center transition border border-gray-800/10 bg-white/10 backdrop-blur-lg dark:bg-black/30 hover:bg-white/20 dark:hover:bg-black/50 dark:border-white/10';
+
+  const prevClasses =
+    'md:text-right first:rounded-t-lg md:first:rounded-tr-none md:first:rounded-l-lg last:rounded-r-lg last:rounded-b-lg last:border-t md:border-r-0 md:last:border-r md:last:rounded-r-none';
+
+  const nextClasses =
+    'border-t-0 border-b-0 md:text-left md:first:rounded-t-lg last:rounded-b-lg first:rounded-l-lg md:last:rounded-bl-none md:last:rounded-r-lg first:border-t md:border-t last:border-b';
+
+  return (
+    <Link
+      href={href}
+      className={`${baseClasses} ${direction === 'previous' ? prevClasses : nextClasses}`}
+    >
+      <p className="mb-4 text-gray-500 uppercase dark:text-white dark:opacity-60">
+        {label}
+      </p>
+      <h4 className="mb-6 text-2xl text-gray-700 dark:text-white">{title}</h4>
+      <ArrowIcon
+        className={`mx-auto mt-auto ${direction === 'previous' ? 'transform rotate-180 md:mr-0' : 'md:ml-0'}`}
+      />
+    </Link>
+  );
+};
+
+export default PostNavCard;

--- a/src/utils/mdxUtils.ts
+++ b/src/utils/mdxUtils.ts
@@ -1,7 +1,7 @@
 import fs from 'fs';
 import path from 'path';
 import matter from 'gray-matter';
-import {serialize} from 'next-mdx-remote/serialize';
+import { serialize } from 'next-mdx-remote/serialize';
 import remarkGfm from 'remark-gfm';
 import rehypePrettyCode from 'rehype-pretty-code';
 import rehypeUnwrapImages from 'rehype-unwrap-images';
@@ -11,92 +11,98 @@ export const POSTS_PATH = path.join(process.cwd(), 'data/posts');
 
 // getPostFilePaths is the list of all mdx files inside the POSTS_PATH directory
 export const getPostFilePaths = () => {
-    return (
-        fs
-            .readdirSync(POSTS_PATH)
-            // Only include md(x) files
-            .filter((path) => /\.mdx?$/.test(path))
-    );
+  return (
+    fs
+      .readdirSync(POSTS_PATH)
+      // Only include md(x) files
+      .filter((path) => /\.mdx?$/.test(path))
+  );
 };
 
 export const sortPostsByDate = (posts) => {
-    return posts.sort((a, b) => {
-        const aDate = new Date(a.data.date).getTime();
-        const bDate = new Date(b.data.date).getTime();
-        return bDate - aDate;
-    });
+  return posts.sort((a, b) => {
+    const aDate = new Date(a.data.date).getTime();
+    const bDate = new Date(b.data.date).getTime();
+    return bDate - aDate;
+  });
 };
 
 export const getPosts = () => {
-    let posts = getPostFilePaths().map((filePath) => {
-        const source = fs.readFileSync(path.join(POSTS_PATH, filePath));
-        const {content, data} = matter(source);
+  let posts = getPostFilePaths().map((filePath) => {
+    const source = fs.readFileSync(path.join(POSTS_PATH, filePath));
+    const { content, data } = matter(source);
 
-        return {
-            content,
-            data,
-            filePath,
-        };
-    });
+    return {
+      content,
+      data,
+      filePath,
+    };
+  });
 
-    posts = sortPostsByDate(posts);
+  posts = sortPostsByDate(posts);
 
-    return posts;
+  return posts;
 };
 
 export const getPostBySlug = async (slug) => {
-    const postFilePath = path.join(POSTS_PATH, `${slug}.mdx`);
-    const source = fs.readFileSync(postFilePath);
+  const postFilePath = path.join(POSTS_PATH, `${slug}.mdx`);
+  const source = fs.readFileSync(postFilePath);
 
-    const {content, data} = matter(source);
+  const { content, data } = matter(source);
 
-    const mdxSource = await serialize(content, {
-        // Optionally pass remark/rehype plugins
-        mdxOptions: {
-            remarkPlugins: [remarkGfm],
-            rehypePlugins: [[rehypePrettyCode, {
-                theme: 'github-dark', // or 'nord', 'dracula', etc.
-                keepBackground: false, // optional
-            }], rehypeUnwrapImages],
-        },
-        scope: data,
-    });
+  const mdxSource = await serialize(content, {
+    // Optionally pass remark/rehype plugins
+    mdxOptions: {
+      remarkPlugins: [remarkGfm],
+      rehypePlugins: [
+        [
+          rehypePrettyCode,
+          {
+            theme: 'github-dark', // or 'nord', 'dracula', etc.
+            keepBackground: false, // optional
+          },
+        ],
+        rehypeUnwrapImages,
+      ],
+    },
+    scope: data,
+  });
 
-    return {mdxSource, data, postFilePath, content};
+  return { mdxSource, data, postFilePath, content };
 };
 
 export const getNextPostBySlug = (slug: string) => {
-    const posts = getPosts();
-    const currentFileName = `${slug}.mdx`;
-    const currentPost = posts.find((post) => post.filePath === currentFileName);
-    const currentPostIndex = posts.indexOf(currentPost);
+  const posts = getPosts();
+  const currentFileName = `${slug}.mdx`;
+  const currentPost = posts.find((post) => post.filePath === currentFileName);
+  const currentPostIndex = posts.indexOf(currentPost);
 
-    const post = posts[currentPostIndex - 1];
-    // no next post found
-    if (!post) return null;
+  const post = posts[currentPostIndex + 1];
+  // no next post found
+  if (!post) return null;
 
-    const nextPostSlug = post?.filePath.replace(/\.mdx?$/, '');
+  const nextPostSlug = post?.filePath.replace(/\.mdx?$/, '');
 
-    return {
-        title: post.data.title,
-        slug: nextPostSlug,
-    };
+  return {
+    title: post.data.title,
+    slug: nextPostSlug,
+  };
 };
 
 export const getPreviousPostBySlug = (slug: string) => {
-    const posts = getPosts();
-    const currentFileName = `${slug}.mdx`;
-    const currentPost = posts.find((post) => post.filePath === currentFileName);
-    const currentPostIndex = posts.indexOf(currentPost);
+  const posts = getPosts();
+  const currentFileName = `${slug}.mdx`;
+  const currentPost = posts.find((post) => post.filePath === currentFileName);
+  const currentPostIndex = posts.indexOf(currentPost);
 
-    const post = posts[currentPostIndex + 1];
-    // no prev post found
-    if (!post) return null;
+  const post = posts[currentPostIndex - 1];
+  // no prev post found
+  if (!post) return null;
 
-    const previousPostSlug = post?.filePath.replace(/\.mdx?$/, '');
+  const previousPostSlug = post?.filePath.replace(/\.mdx?$/, '');
 
-    return {
-        title: post.data.title,
-        slug: previousPostSlug,
-    };
+  return {
+    title: post.data.title,
+    slug: previousPostSlug,
+  };
 };


### PR DESCRIPTION
## Summary
- create `PostNavCard` component for next/previous navigation
- use `PostNavCard` in post pages
- fix order of `getNextPostBySlug` and `getPreviousPostBySlug`

## Testing
- `yarn lint`

------
https://chatgpt.com/codex/tasks/task_e_6858bbeb6270832891d07ae1377083da